### PR TITLE
fix: correct metadata field path and silent empty embedding bug

### DIFF
--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -849,15 +849,23 @@ async def embed_file(
                 detail="Failed to process/store the file data.",
             )
         elif "error" in result:
-            response_status = False
-            response_message = "Failed to process/store the file data."
-            if isinstance(result["error"], str):
-                response_message = result["error"]
-            else:
-                raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail="An unspecified error occurred.",
-                )
+            error_detail = (
+                result["error"]
+                if isinstance(result["error"], str)
+                else "An unspecified error occurred."
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=error_detail,
+            )
+        elif not result.get("ids"):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "No content could be extracted from the file. "
+                    "The file may be empty, image-only, or in an unsupported format."
+                ),
+            )
     except HTTPException as http_exc:
         response_status = False
         response_message = f"HTTP Exception: {http_exc.detail}"

--- a/app/services/vector_store/atlas_mongo_vector.py
+++ b/app/services/vector_store/atlas_mongo_vector.py
@@ -71,9 +71,9 @@ class AtlasMongoVector(MongoDBAtlasVectorSearch):
                 page_content=doc["text"],
                 metadata={
                     "file_id": doc["metadata"]["file_id"],
-                    "user_id": doc["metadata"]["user_id"],
-                    "digest": doc["metadata"]["digest"],
-                    "source": doc["metadata"]["source"],
+                    "user_id": doc["metadata"].get("user_id", ""),
+                    "digest": doc["metadata"].get("digest", ""),
+                    "source": doc["metadata"].get("source", ""),
                     "page": int(doc["metadata"].get("page", 0)),
                 },
             )

--- a/app/services/vector_store/atlas_mongo_vector.py
+++ b/app/services/vector_store/atlas_mongo_vector.py
@@ -55,30 +55,32 @@ class AtlasMongoVector(MongoDBAtlasVectorSearch):
         return processed_documents
 
     def get_all_ids(self) -> list[str]:
-        # Return unique file_id fields in self._collection
-        return self._collection.distinct("file_id")
+        # Return unique file_id values stored under the nested metadata field
+        return self._collection.distinct("metadata.file_id")
 
     def get_filtered_ids(self, ids: list[str]) -> list[str]:
-        # Return unique file_id fields filtered by the provided ids
-        return self._collection.distinct("file_id", {"file_id": {"$in": ids}})
+        # Return unique file_id values filtered by the provided ids
+        return self._collection.distinct(
+            "metadata.file_id", {"metadata.file_id": {"$in": ids}}
+        )
 
     def get_documents_by_ids(self, ids: list[str]) -> list[Document]:
-        # Return documents filtered by file_id
+        # Return documents filtered by file_id stored in the nested metadata field
         return [
             Document(
                 page_content=doc["text"],
                 metadata={
-                    "file_id": doc["file_id"],
-                    "user_id": doc["user_id"],
-                    "digest": doc["digest"],
-                    "source": doc["source"],
-                    "page": int(doc.get("page", 0)),
+                    "file_id": doc["metadata"]["file_id"],
+                    "user_id": doc["metadata"]["user_id"],
+                    "digest": doc["metadata"]["digest"],
+                    "source": doc["metadata"]["source"],
+                    "page": int(doc["metadata"].get("page", 0)),
                 },
             )
-            for doc in self._collection.find({"file_id": {"$in": ids}})
+            for doc in self._collection.find({"metadata.file_id": {"$in": ids}})
         ]
 
     def delete(self, ids: Optional[list[str]] = None) -> None:
-        # Delete documents by file_id
+        # Delete documents by file_id stored in the nested metadata field
         if ids is not None:
-            self._collection.delete_many({"file_id": {"$in": ids}})
+            self._collection.delete_many({"metadata.file_id": {"$in": ids}})


### PR DESCRIPTION
langchain_mongodb 0.11.0 stores document metadata nested under a 'metadata' subdocument rather than flat at the top level. All MongoDB queries in AtlasMongoVector were referencing 'file_id' directly, causing every context lookup (GET /documents/{id}/context) to return 404 even after a successful embed, because the field is actually stored at 'metadata.file_id'.

- atlas_mongo_vector.py: update get_all_ids, get_filtered_ids, get_documents_by_ids, and delete to use 'metadata.file_id' field path and read nested metadata fields correctly.

- document_routes.py: fix silent empty embedding bug in /embed endpoint where a string error from store_data_in_vector_db returned HTTP 200 with status=False instead of raising an HTTPException. Also add a check for an empty ids list so files that produce zero chunks (e.g. image-only PDFs) are rejected with HTTP 422 rather than silently appearing as successfully uploaded.

Made-with: Cursor